### PR TITLE
Android Continuous Integration

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,17 @@
+name: Android CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Build with Gradle
+      run: ./gradlew build

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -8,10 +8,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: set up JDK 1.8
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Set up JDK 1.8
       uses: actions/setup-java@v1
-      with:
+      with: 
         java-version: 1.8
+    - name: Make gradlew executable
+      run: chmod +x ./gradlew
     - name: Build with Gradle
-      run: ./gradlew build
+      run: ./gradlew build --scan


### PR DESCRIPTION
Added script to run an automatic Gradle build when pushing. Has been in the shared repo for a fairly long time, helps spot failing tests while still allowing to push.
Together with Codacy helps us keep the repo clean overall.