### PR TITLE
Updated the 'equals' method for SMSContact class

### DIFF
--- a/app/src/main/java/ingsw/group1/findmyphone/contacts/SMSContact.java
+++ b/app/src/main/java/ingsw/group1/findmyphone/contacts/SMSContact.java
@@ -97,8 +97,7 @@ public class SMSContact implements GenericContact<String, SMSPeer> {
         if (obj == this)
             return true;
         SMSContact contactMaybeEquals = (SMSContact) obj;
-        return (name.equals(contactMaybeEquals.getName())
-                && address.equals(contactMaybeEquals.getAddress()));
+        return address.equals(contactMaybeEquals.getAddress());
     }
 
 


### PR DESCRIPTION
## Premise

Two contacts are equals when they have the same address and not also the same name.

## Changes

- Method 'equals' in `SMSContact `class
