### PR TITLE
Hotfix/contact selection

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,22 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <compositeConfiguration>
-          <compositeBuild compositeDefinitionSource="SCRIPT" />
-        </compositeConfiguration>
+        <option name="testRunner" value="PLATFORM" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/app" />
-            <option value="$PROJECT_DIR$/ingsw-group1-message-library/msglibrary" />
           </set>
         </option>
         <option name="resolveModulePerSourceSet" value="false" />
-        <option name="testRunner" value="PLATFORM" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/app/src/main/java/ingsw/group1/findmyphone/activity/MainActivity.java
+++ b/app/src/main/java/ingsw/group1/findmyphone/activity/MainActivity.java
@@ -20,6 +20,7 @@ import com.eis.smslibrary.SMSPeer;
 import ingsw.group1.findmyphone.Manager;
 import ingsw.group1.findmyphone.R;
 import ingsw.group1.findmyphone.ServiceManager;
+import ingsw.group1.findmyphone.contacts.GenericContact;
 import ingsw.group1.findmyphone.contacts.SMSContact;
 import ingsw.group1.findmyphone.contacts.SMSContactRecyclerAdapter;
 
@@ -42,7 +43,7 @@ public class MainActivity extends AppCompatActivity {
     };
     private final int APP_PERMISSION_REQUEST_CODE = 1;
 
-    public static SMSContact contactSelected = null;
+    private static SMSContact contactSelected = null;
 
     private EditText txtPhoneNumber;
     private ImageButton sendAlarmRequestButton;
@@ -75,8 +76,6 @@ public class MainActivity extends AppCompatActivity {
         manager = new Manager(getApplicationContext());
         manager.setReceiveListener(ServiceManager.class);
 
-        setPhoneNumber();
-
         sendLocationRequestButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -102,12 +101,22 @@ public class MainActivity extends AppCompatActivity {
 
     }
 
+    //---------------------------- STATIC METHODS TO SET selected contact FROM SMSContactRecyclerAdapter ----------
+
     /**
-     * Set phone number in his EditText with address of contact selected from contact list.
+     * Return {@link SMSContact} selected contact whose address is shown in this view.
      */
-    public void setPhoneNumber(){
-        if(contactSelected != null)
-            txtPhoneNumber.setText(contactSelected.getAddress());
+    public static SMSContact getContactSelected(){
+        return contactSelected;
+    }
+
+    /**
+     * Set contact selected from contacts list.
+     *
+     * @param newContactSelected    {@link SMSContact} contact selected from contacts list.
+     */
+    public static void setContactSelected(SMSContact newContactSelected){
+        contactSelected = newContactSelected;
     }
 
     /**
@@ -117,8 +126,11 @@ public class MainActivity extends AppCompatActivity {
      */
     @Override
     protected void onResume() {
-        setPhoneNumber();
         super.onResume();
+        if(contactSelected != null)
+            txtPhoneNumber.setText(contactSelected.getAddress());
+        else
+            txtPhoneNumber.setText("");
     }
 
     @Override

--- a/app/src/main/java/ingsw/group1/findmyphone/activity/MainActivity.java
+++ b/app/src/main/java/ingsw/group1/findmyphone/activity/MainActivity.java
@@ -103,6 +103,8 @@ public class MainActivity extends AppCompatActivity {
 
     /**
      * Return {@link SMSContact} selected contact whose address is shown in this view.
+     *
+     * @author Giorgia Bortoletti
      */
     public static SMSContact getContactSelected(){
         return contactSelected;
@@ -112,6 +114,8 @@ public class MainActivity extends AppCompatActivity {
      * Set contact selected from contacts list.
      *
      * @param newContactSelected    {@link SMSContact} contact selected from contacts list.
+     *
+     * @author Giorgia Bortoletti
      */
     public static void setContactSelected(SMSContact newContactSelected){
         contactSelected = newContactSelected;
@@ -121,6 +125,8 @@ public class MainActivity extends AppCompatActivity {
      * This method is invoked after an onBack of another activity.
      * This is used to see if the phone number is been selected from contact list
      * and the number is updated.
+     *
+     * @author Giorgia Bortoletti
      */
     @Override
     protected void onResume() {

--- a/app/src/main/java/ingsw/group1/findmyphone/activity/MainActivity.java
+++ b/app/src/main/java/ingsw/group1/findmyphone/activity/MainActivity.java
@@ -20,9 +20,7 @@ import com.eis.smslibrary.SMSPeer;
 import ingsw.group1.findmyphone.Manager;
 import ingsw.group1.findmyphone.R;
 import ingsw.group1.findmyphone.ServiceManager;
-import ingsw.group1.findmyphone.contacts.GenericContact;
 import ingsw.group1.findmyphone.contacts.SMSContact;
-import ingsw.group1.findmyphone.contacts.SMSContactRecyclerAdapter;
 
 
 /**

--- a/app/src/main/java/ingsw/group1/findmyphone/activity/MainActivity.java
+++ b/app/src/main/java/ingsw/group1/findmyphone/activity/MainActivity.java
@@ -20,6 +20,8 @@ import com.eis.smslibrary.SMSPeer;
 import ingsw.group1.findmyphone.Manager;
 import ingsw.group1.findmyphone.R;
 import ingsw.group1.findmyphone.ServiceManager;
+import ingsw.group1.findmyphone.contacts.SMSContact;
+import ingsw.group1.findmyphone.contacts.SMSContactRecyclerAdapter;
 
 
 /**
@@ -40,6 +42,8 @@ public class MainActivity extends AppCompatActivity {
     };
     private final int APP_PERMISSION_REQUEST_CODE = 1;
 
+    public static SMSContact contactSelected = null;
+
     private EditText txtPhoneNumber;
     private ImageButton sendAlarmRequestButton;
     private ImageButton sendLocationRequestButton;
@@ -59,6 +63,7 @@ public class MainActivity extends AppCompatActivity {
         ImageButton viewContacts;
 
         txtPhoneNumber = findViewById(R.id.phoneNumber);
+
         sendAlarmRequestButton = findViewById(R.id.sendAlarmRequestButton);
         sendLocationRequestButton = findViewById(R.id.sendLocationRequestButton);
         viewContacts = findViewById(R.id.view_contact_list);
@@ -69,6 +74,8 @@ public class MainActivity extends AppCompatActivity {
 
         manager = new Manager(getApplicationContext());
         manager.setReceiveListener(ServiceManager.class);
+
+        setPhoneNumber();
 
         sendLocationRequestButton.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -95,6 +102,24 @@ public class MainActivity extends AppCompatActivity {
 
     }
 
+    /**
+     * Set phone number in his EditText with address of contact selected from contact list.
+     */
+    public void setPhoneNumber(){
+        if(contactSelected != null)
+            txtPhoneNumber.setText(contactSelected.getAddress());
+    }
+
+    /**
+     * This method is invoked after an onBack of another activity.
+     * This is used to see if the phone number is been selected from contact list
+     * and the number is updated.
+     */
+    @Override
+    protected void onResume() {
+        setPhoneNumber();
+        super.onResume();
+    }
 
     @Override
     protected void onStart() {

--- a/app/src/main/java/ingsw/group1/findmyphone/contacts/SMSContactRecyclerAdapter.java
+++ b/app/src/main/java/ingsw/group1/findmyphone/contacts/SMSContactRecyclerAdapter.java
@@ -1,5 +1,6 @@
 package ingsw.group1.findmyphone.contacts;
 
+import android.content.Context;
 import android.graphics.Color;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -10,12 +11,14 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.constraintlayout.widget.ConstraintLayout;
+import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.RecyclerView;
 
 import java.util.List;
 
 import ingsw.group1.findmyphone.R;
 import ingsw.group1.findmyphone.activity.ContactListActivity;
+import ingsw.group1.findmyphone.activity.MainActivity;
 
 /**
  * Class adapter
@@ -34,10 +37,7 @@ public class SMSContactRecyclerAdapter extends RecyclerView.Adapter<SMSContactRe
     private List<SMSContact> contacts; //contacts filtered
     private SMSContactManager contactManager;
     private Filter filter; //filter used in the searchView to filter contacts by name and address
-
-    // if checkedPosition = -1, there is no default selection
-    // if checkedPosition = 0, 1st item is selected by default
-    private int selectedPosition = -1;
+    private int selectedPosition;
 
     //---------------------------- CONSTRUCTOR ----------------------------
 
@@ -50,7 +50,7 @@ public class SMSContactRecyclerAdapter extends RecyclerView.Adapter<SMSContactRe
     public SMSContactRecyclerAdapter(final List<SMSContact> contacts, SMSContactManager contactManager) {
         this.contacts = contacts;
         this.contactManager = contactManager;
-
+        this.selectedPosition = -1;
         this.filter = new ContactFilter(this, contacts);
     }
 
@@ -121,9 +121,11 @@ public class SMSContactRecyclerAdapter extends RecyclerView.Adapter<SMSContactRe
     /**
      * Return {@link SMSContact} to the selected position.
      *
-     * @return {@link SMSContact} to the selected position
+     * @return {@link SMSContact} to the selected position, null if there isn't a selected position.
      */
     public SMSContact getSelectedItem() {
+        if(selectedPosition == -1)
+            return null;
         return contacts.get(selectedPosition);
     }
 
@@ -179,7 +181,6 @@ public class SMSContactRecyclerAdapter extends RecyclerView.Adapter<SMSContactRe
     public class ContactViewHolder extends RecyclerView.ViewHolder {
         public TextView contactName;
         public TextView contactAddress;
-
         public ConstraintLayout layout;
 
         /**
@@ -201,17 +202,19 @@ public class SMSContactRecyclerAdapter extends RecyclerView.Adapter<SMSContactRe
          * @param contact   To set in the item.
          */
         public void bind(SMSContact contact) {
+            layout.setBackgroundColor(Color.WHITE);
+            contactName.setText(contact.getName());
+            contactAddress.setText(contact.getAddress());
 
-            this.contactName.setText(contact.getName());
-            this.contactAddress.setText(contact.getAddress());
-
+            //this listener is used to change status of a selected item after a click
             itemView.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View view) {
-                    layout.setBackgroundColor(Color.YELLOW);
+                    layout.setBackgroundColor(ContextCompat.getColor(view.getContext(), R.color.selectedContact));
                     if (selectedPosition != getAdapterPosition()) {
                         notifyItemChanged(selectedPosition);
                         selectedPosition = getAdapterPosition();
+                        MainActivity.contactSelected = getSelectedItem();
                     }
                 }
             });

--- a/app/src/main/java/ingsw/group1/findmyphone/contacts/SMSContactRecyclerAdapter.java
+++ b/app/src/main/java/ingsw/group1/findmyphone/contacts/SMSContactRecyclerAdapter.java
@@ -1,5 +1,6 @@
 package ingsw.group1.findmyphone.contacts;
 
+import android.graphics.Color;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -8,6 +9,7 @@ import android.widget.Filterable;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.recyclerview.widget.RecyclerView;
 
 import java.util.List;
@@ -32,6 +34,10 @@ public class SMSContactRecyclerAdapter extends RecyclerView.Adapter<SMSContactRe
     private List<SMSContact> contacts; //contacts filtered
     private SMSContactManager contactManager;
     private Filter filter; //filter used in the searchView to filter contacts by name and address
+
+    // if checkedPosition = -1, there is no default selection
+    // if checkedPosition = 0, 1st item is selected by default
+    private int selectedPosition = -1;
 
     //---------------------------- CONSTRUCTOR ----------------------------
 
@@ -76,8 +82,7 @@ public class SMSContactRecyclerAdapter extends RecyclerView.Adapter<SMSContactRe
      */
     @Override
     public void onBindViewHolder(@NonNull ContactViewHolder holder, int position) {
-        holder.contactName.setText(contacts.get(position).getName());
-        holder.contactAddress.setText(contacts.get(position).getAddress());
+        holder.bind(contacts.get(position));
     }
 
     //---------------------------- RESEARCH FILTER ----------------------------
@@ -111,6 +116,15 @@ public class SMSContactRecyclerAdapter extends RecyclerView.Adapter<SMSContactRe
      */
     public SMSContact getItem(int position) {
         return contacts.get(position);
+    }
+
+    /**
+     * Return {@link SMSContact} to the selected position.
+     *
+     * @return {@link SMSContact} to the selected position
+     */
+    public SMSContact getSelectedItem() {
+        return contacts.get(selectedPosition);
     }
 
     /**
@@ -166,6 +180,8 @@ public class SMSContactRecyclerAdapter extends RecyclerView.Adapter<SMSContactRe
         public TextView contactName;
         public TextView contactAddress;
 
+        public ConstraintLayout layout;
+
         /**
          * Constructor
          *
@@ -175,6 +191,30 @@ public class SMSContactRecyclerAdapter extends RecyclerView.Adapter<SMSContactRe
             super(itemView);
             contactName = itemView.findViewById(R.id.contact_name);
             contactAddress = itemView.findViewById(R.id.contact_address);
+            layout = itemView.findViewById(R.id.contact_item);
+        }
+
+        /**
+         * Set the item
+         * in its TextView and in its Listener to select one.
+         *
+         * @param contact   To set in the item.
+         */
+        public void bind(SMSContact contact) {
+
+            this.contactName.setText(contact.getName());
+            this.contactAddress.setText(contact.getAddress());
+
+            itemView.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View view) {
+                    layout.setBackgroundColor(Color.YELLOW);
+                    if (selectedPosition != getAdapterPosition()) {
+                        notifyItemChanged(selectedPosition);
+                        selectedPosition = getAdapterPosition();
+                    }
+                }
+            });
         }
 
     }

--- a/app/src/main/res/layout/recycler_contact_item.xml
+++ b/app/src/main/res/layout/recycler_contact_item.xml
@@ -7,6 +7,7 @@
     android:orientation="vertical">
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/contact_item"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_margin="8dp">

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -9,4 +9,5 @@
     <color name="baseTextColor">#444444</color>
     <color name="modifiedEventColor">#012488</color>
     <color name="searchSpanColor">#4287f5</color>
+    <color name="selectedContact">#A8FFEB3B</color>
 </resources>


### PR DESCRIPTION
## Premise

Now user can select a contact and have its phone number in the home screen.
The item's background changes color and the contact is saved in the `MainActivity`. So when home screen is resumed the EditText with phone is set with phone number of selected contact.
When you re-open contacts list, previous selected contact remains highlighted.
If you click on it and come back to home, the EditText returns empty.
_For now, to go back to the home you have to press the back button. I haven't added any buttons or timers._

## Changes

- Set a Listener on contact Item (`ContactViewHolder`).
- Add some static methods in the `MainActivity` to set selected contact from `SMSContactRecylerAdapter`.

### Footer

After merging PR of Riccardo, I'll update this code in the Fragments.
